### PR TITLE
[codex] Publish homepage refresh and highlight fix

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -33,11 +33,6 @@
             <a href="{{ site.baseurl }}/about/"{% if page.url contains '/about' %} aria-current="page"{% endif %}>关于</a>
         </div>
 
-        {% if latest_daily %}
-        <a class="editorial-nav__cta" href="{{ latest_daily.url | prepend: site.baseurl }}">READ TODAY'S ISSUE ↗</a>
-        {% else %}
-        <a class="editorial-nav__cta" href="{{ site.baseurl }}/ai-daily/">AI FRONTIER DAILY ↗</a>
-        {% endif %}
     </div>
 </nav>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,6 +12,10 @@ layout: default
   {% assign category_label = "Company intelligence" %}
   {% assign category_name = "公司观察" %}
   {% assign category_url = "/company-research/" %}
+{% elsif page.categories contains 'reddit' %}
+  {% assign category_label = "Reddit daily digest" %}
+  {% assign category_name = "Reddit 精选" %}
+  {% assign category_url = "/reddit-daily/" %}
 {% endif %}
 
 <header class="article-hero{% if page.categories contains 'ai-daily' %} article-hero--daily{% endif %}">

--- a/css/editorial.css
+++ b/css/editorial.css
@@ -102,7 +102,7 @@ body {
 .editorial-nav__inner {
   min-height: 68px;
   display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
   gap: 28px;
 }
@@ -138,6 +138,7 @@ body {
 .editorial-nav__links {
   display: flex;
   align-items: center;
+  justify-self: end;
   gap: 28px;
   font-family: var(--font-ui);
   font-size: 14px;
@@ -174,28 +175,6 @@ body {
 .editorial-nav__links a:hover::after,
 .editorial-nav__links a[aria-current="page"]::after {
   transform: scaleX(1);
-}
-
-.editorial-nav__cta,
-.editorial-nav__cta:hover,
-.editorial-nav__cta:focus {
-  justify-self: end;
-  color: #ffffff;
-  background: var(--editorial-coral);
-  border: 0;
-  border-radius: var(--radius-md);
-  padding: 10px 16px;
-  font-family: var(--font-ui);
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: .03em;
-  text-decoration: none;
-  transition: background .15s ease;
-}
-
-.editorial-nav__cta:hover,
-.editorial-nav__cta:focus {
-  background: var(--editorial-coral-active);
 }
 
 .editorial-nav__toggle {
@@ -503,67 +482,129 @@ body {
   transform: rotate(45deg);
 }
 
-.today-updates {
-  display: grid;
-  grid-template-columns: minmax(260px, .8fr) minmax(0, 2.2fr);
+.today-carousel {
+  padding-top: 22px;
+  padding-bottom: 20px;
   border-bottom: 1px solid var(--editorial-line);
 }
 
-.today-updates__rail {
-  min-height: 190px;
+.today-carousel__header {
   display: flex;
-  flex-direction: column;
+  align-items: flex-end;
   justify-content: space-between;
-  padding: 30px 36px 32px 0;
-  border-right: 1px solid var(--editorial-line);
+  gap: 24px;
+  margin-bottom: 14px;
 }
 
-.today-updates__rail > div {
+.today-carousel__header > div:first-child {
   display: flex;
   align-items: baseline;
-  gap: 10px;
+  gap: 14px;
 }
 
-.today-updates__rail strong {
-  font-family: var(--font-display);
-  font-size: 38px;
-  font-weight: 400;
-  line-height: 1;
+.today-carousel__header p {
+  margin: 0;
+  color: var(--editorial-ink);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: .12em;
+  text-transform: uppercase;
 }
 
-.today-updates__rail span {
+.today-carousel__header span {
   color: var(--editorial-muted);
   font-family: var(--font-ui);
   font-size: 11px;
 }
 
-.today-updates__list {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0;
-  padding: 30px 0 32px 48px;
-}
-
-.today-update-card {
-  position: relative;
-  min-width: 0;
-  min-height: 128px;
+.today-carousel__controls {
   display: flex;
-  flex-direction: column;
-  padding: 3px 24px 0;
-  border-left: 1px solid var(--editorial-line);
+  gap: 7px;
 }
 
-.today-update-card:nth-child(3n + 1) {
-  padding-left: 0;
-  border-left: 0;
+.today-carousel__controls button {
+  width: 31px;
+  height: 31px;
+  padding: 0;
+  color: var(--editorial-ink);
+  background: transparent;
+  border: 1px solid var(--editorial-line);
+  border-radius: 50%;
+  font-family: var(--font-ui);
+  font-size: 14px;
+  line-height: 1;
+  transition: color .15s ease, background .15s ease, border-color .15s ease;
 }
 
-.today-update-card > div {
+.today-carousel__controls button:hover:not(:disabled),
+.today-carousel__controls button:focus-visible:not(:disabled) {
+  color: #ffffff;
+  background: var(--editorial-coral);
+  border-color: var(--editorial-coral);
+}
+
+.today-carousel__controls button:disabled {
+  color: var(--editorial-muted-soft);
+  cursor: default;
+  opacity: .35;
+}
+
+.today-carousel__viewport {
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-behavior: smooth;
+  scroll-snap-type: x mandatory;
+  scrollbar-color: var(--editorial-coral) var(--editorial-line-soft);
+  scrollbar-width: thin;
+}
+
+.today-carousel__viewport:focus-visible {
+  outline: 2px solid rgba(204, 120, 92, .45);
+  outline-offset: 4px;
+}
+
+.today-carousel__viewport::-webkit-scrollbar {
+  height: 4px;
+}
+
+.today-carousel__viewport::-webkit-scrollbar-track {
+  background: var(--editorial-line-soft);
+  border-radius: 99px;
+}
+
+.today-carousel__viewport::-webkit-scrollbar-thumb {
+  background: var(--editorial-coral);
+  border-radius: 99px;
+}
+
+.today-carousel__track {
+  width: max-content;
+  display: flex;
+  gap: 10px;
+  padding-bottom: 12px;
+}
+
+.today-carousel__card {
+  position: relative;
+  width: clamp(250px, 26vw, 312px);
+  min-height: 106px;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  flex: 0 0 auto;
+  padding: 14px 42px 14px 16px;
+  background: rgba(239, 233, 222, .48);
+  border: 1px solid var(--editorial-line-soft);
+  border-radius: var(--radius-md);
+  scroll-snap-align: start;
+  transition: background .15s ease, border-color .15s ease;
+}
+
+.today-carousel__card > div {
   display: flex;
   justify-content: space-between;
   gap: 12px;
-  margin-bottom: 18px;
+  margin-bottom: 9px;
   color: var(--editorial-muted);
   font-family: var(--font-ui);
   font-size: 9px;
@@ -572,32 +613,33 @@ body {
   text-transform: uppercase;
 }
 
-.today-update-card h3 {
+.today-carousel__card h3 {
   margin: 0;
-  padding-right: 15px;
   font-family: var(--font-display);
-  font-size: clamp(17px, 1.5vw, 21px);
+  font-size: 17px;
   font-weight: 400;
-  line-height: 1.45;
+  line-height: 1.35;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 2;
   overflow: hidden;
 }
 
-.today-update-card > span {
-  align-self: flex-end;
-  margin-top: auto;
+.today-carousel__card > span {
+  position: absolute;
+  right: 16px;
+  bottom: 14px;
   color: var(--editorial-coral);
-  font-size: 17px;
+  font-size: 15px;
   transition: transform .18s ease;
 }
 
-.today-update-card:hover h3 {
-  color: var(--editorial-coral-active);
+.today-carousel__card:hover {
+  background: var(--editorial-card);
+  border-color: var(--editorial-cream-strong);
 }
 
-.today-update-card:hover > span {
+.today-carousel__card:hover > span {
   transform: translate(3px, -3px);
 }
 
@@ -2623,14 +2665,12 @@ footer .copyright {
     border-top: 1px solid var(--editorial-line-soft);
   }
 
-  .editorial-nav__links a::after,
-  .editorial-nav__cta {
+  .editorial-nav__links a::after {
     display: none;
   }
 
   .editorial-hero__grid,
-  .daily-lead,
-  .today-updates {
+  .daily-lead {
     grid-template-columns: 1fr;
   }
 
@@ -2656,33 +2696,6 @@ footer .copyright {
   .daily-lead__story {
     min-height: auto;
     padding-left: 0;
-  }
-
-  .today-updates__rail {
-    min-height: 0;
-    padding-right: 0;
-    border-right: 0;
-    border-bottom: 1px solid var(--editorial-line);
-  }
-
-  .today-updates__rail > div {
-    margin-top: 28px;
-  }
-
-  .today-updates__list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    padding-left: 0;
-  }
-
-  .today-update-card,
-  .today-update-card:nth-child(3n + 1) {
-    padding-left: 22px;
-    border-left: 1px solid var(--editorial-line);
-  }
-
-  .today-update-card:nth-child(odd) {
-    padding-left: 0;
-    border-left: 0;
   }
 
   .finance-grid {
@@ -2908,32 +2921,32 @@ footer .copyright {
     margin-top: 36px;
   }
 
-  .today-updates__rail {
-    padding-top: 25px;
-    padding-bottom: 25px;
+  .today-carousel {
+    padding-top: 14px;
+    padding-bottom: 12px;
   }
 
-  .today-updates__list {
-    grid-template-columns: 1fr;
-    padding-top: 8px;
-    padding-bottom: 14px;
+  .today-carousel__header {
+    margin-bottom: 10px;
   }
 
-  .today-update-card,
-  .today-update-card:nth-child(3n + 1),
-  .today-update-card:nth-child(odd) {
-    min-height: 0;
-    padding: 22px 0 20px;
-    border-top: 1px solid var(--editorial-line);
-    border-left: 0;
+  .today-carousel__header > div:first-child {
+    display: block;
   }
 
-  .today-update-card:first-child {
-    border-top: 0;
+  .today-carousel__header p {
+    margin-bottom: 4px;
   }
 
-  .today-update-card > span {
-    margin-top: 18px;
+  .today-carousel__card {
+    width: min(78vw, 288px);
+    min-height: 96px;
+    padding: 12px 40px 12px 14px;
+  }
+
+  .today-carousel__card > span {
+    right: 14px;
+    bottom: 12px;
   }
 
   .editorial-content-section,

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "首页"
-description: "每天筛选值得关注的 AI 信号；用财报、产品与数据，持续记录技术如何改变商业和人的选择。"
+description: "从 AI 前沿、公司变化到 Reddit 社区与个人思考，持续筛选当下值得理解、值得保存、也值得日后重读的内容。"
 ---
 
 {% assign today_key = site.time | date: "%Y-%m-%d" %}
@@ -49,13 +49,14 @@ description: "每天筛选值得关注的 AI 信号；用财报、产品与数�
     <section class="editorial-hero">
         <div class="editorial-shell editorial-hero__grid">
             <div class="editorial-hero__copy">
-                <p class="editorial-eyebrow">产品 · 数据 · AI</p>
-                <h1>读懂 AI 进展，<br>也看公司<em>真实增长</em></h1>
-                <p class="editorial-hero__note">每天筛选值得关注的 AI 信号；用财报、产品与数据，持续记录技术如何改变商业和人的选择。</p>
+                <p class="editorial-eyebrow">技术 · 商业 · 社区 · 思考</p>
+                <h1>追踪正在发生的，<br>留下<em>有趣且有价值</em>的内容</h1>
+                <p class="editorial-hero__note">从 AI 前沿、公司变化到 Reddit 社区与个人思考，持续筛选当下值得理解、值得保存，也值得日后重读的内容。</p>
             </div>
             <aside class="editorial-manifesto">
                 <span>EDITOR'S NOTE / 001</span>
-                <p>这里不追逐所有热点。日报负责速度，公司观察负责深度，长期文章负责留下判断。</p>
+                <p>信息每天都在过期，真正有价值的判断不会。这里追踪变化，也收藏那些让人停一下、想一想、值得反复回看的内容。</p>
+                <a class="editorial-manifesto__link" href="{{ site.baseurl }}/highlights/">打开读者精选流 ↗</a>
             </aside>
         </div>
     </section>
@@ -106,30 +107,41 @@ description: "每天筛选值得关注的 AI 信号；用财报、产品与数�
 
         {% assign secondary_count = today_posts | size | minus: 1 %}
         {% if has_today_posts and secondary_count > 0 %}
-        <div class="editorial-shell today-updates" aria-label="今日其他更新">
-            <header class="today-updates__rail">
-                <p class="editorial-section-label">Also published today</p>
-                <div><strong>{{ secondary_count }}</strong><span>篇新内容</span></div>
+        <div class="editorial-shell today-carousel" data-today-carousel aria-label="今日其他更新">
+            <header class="today-carousel__header">
+                <div>
+                    <p>Also today</p>
+                    <span>今天还更新了 {{ secondary_count }} 篇</span>
+                </div>
+                <div class="today-carousel__controls" aria-label="切换今日更新">
+                    <button type="button" data-carousel-previous aria-label="查看前面的更新">←</button>
+                    <button type="button" data-carousel-next aria-label="查看后面的更新">→</button>
+                </div>
             </header>
-            <div class="today-updates__list">
-                {% for post in today_posts %}
-                    {% unless post.url == primary_post.url %}
-                    {% assign update_category = "思考与实践" %}
-                    {% if post.categories contains 'ai-daily' %}
-                        {% assign update_category = "AI 日报" %}
-                    {% elsif post.categories contains 'company-research' %}
-                        {% assign update_category = "公司观察" %}
-                    {% elsif post.categories contains 'reddit' %}
-                        {% assign update_category = "Reddit 精选" %}
-                    {% endif %}
-                    {% assign update_time = post.date | date: "%H:%M" %}
-                    <a class="today-update-card" href="{{ post.url | prepend: site.baseurl }}">
-                        <div><span>{{ update_category }}</span><time datetime="{{ post.date | date_to_xmlschema }}">{% if update_time == "00:00" %}今日{% else %}{{ update_time }}{% endif %}</time></div>
-                        <h3>{{ post.headline | default: post.title }}</h3>
-                        <span aria-hidden="true">↗</span>
-                    </a>
-                    {% endunless %}
-                {% endfor %}
+            <div class="today-carousel__viewport" data-carousel-viewport tabindex="0">
+                <div class="today-carousel__track">
+                    {% for post in today_posts %}
+                        {% unless post.url == primary_post.url %}
+                        {% assign update_category = "思考与实践" %}
+                        {% if post.categories contains 'ai-daily' %}
+                            {% assign update_category = "AI 日报" %}
+                        {% elsif post.categories contains 'company-research' %}
+                            {% assign update_category = "公司观察" %}
+                        {% elsif post.categories contains 'reddit' %}
+                            {% assign update_category = "Reddit 精选" %}
+                        {% endif %}
+                        {% assign update_time = post.date | date: "%H:%M" %}
+                        <a class="today-carousel__card" href="{{ post.url | prepend: site.baseurl }}">
+                            <div>
+                                <span>{{ update_category }}</span>
+                                <time datetime="{{ post.date | date_to_xmlschema }}">{% if update_time == "00:00" %}今日{% else %}{{ update_time }}{% endif %}</time>
+                            </div>
+                            <h3>{{ post.headline | default: post.title }}</h3>
+                            <span aria-hidden="true">↗</span>
+                        </a>
+                        {% endunless %}
+                    {% endfor %}
+                </div>
             </div>
         </div>
         {% endif %}
@@ -184,3 +196,33 @@ description: "每天筛选值得关注的 AI 信号；用财报、产品与数�
         </div>
     </section>
 </main>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('[data-today-carousel]').forEach(function (carousel) {
+        var viewport = carousel.querySelector('[data-carousel-viewport]');
+        var previous = carousel.querySelector('[data-carousel-previous]');
+        var next = carousel.querySelector('[data-carousel-next]');
+        if (!viewport || !previous || !next) return;
+
+        function updateControls() {
+            var maxScroll = viewport.scrollWidth - viewport.clientWidth;
+            previous.disabled = viewport.scrollLeft <= 2;
+            next.disabled = viewport.scrollLeft >= maxScroll - 2;
+        }
+
+        function move(direction) {
+            viewport.scrollBy({
+                left: direction * Math.max(280, viewport.clientWidth * 0.72),
+                behavior: 'smooth'
+            });
+        }
+
+        previous.addEventListener('click', function () { move(-1); });
+        next.addEventListener('click', function () { move(1); });
+        viewport.addEventListener('scroll', updateControls, { passive: true });
+        window.addEventListener('resize', updateControls);
+        updateControls();
+    });
+});
+</script>

--- a/js/highlights.js
+++ b/js/highlights.js
@@ -183,6 +183,19 @@ function setupSelectionTool() {
         active = null;
     }
 
+    function selectionIsBackward(selection) {
+        if (!selection.anchorNode || !selection.focusNode) return false;
+
+        const directionProbe = document.createRange();
+        try {
+            directionProbe.setStart(selection.anchorNode, selection.anchorOffset);
+            directionProbe.setEnd(selection.focusNode, selection.focusOffset);
+            return directionProbe.collapsed;
+        } catch (error) {
+            return false;
+        }
+    }
+
     function selectionInsideSource(selection) {
         if (!selection || selection.isCollapsed || !selection.rangeCount) return null;
         const range = selection.getRangeAt(0);
@@ -190,17 +203,21 @@ function setupSelectionTool() {
 
         const quote = normalizedText(selection.toString());
         if (quote.length < 2) return null;
-        return { quote: quote.slice(0, MAX_QUOTE_LENGTH), range: range.cloneRange() };
+        return {
+            quote: quote.slice(0, MAX_QUOTE_LENGTH),
+            range: range.cloneRange(),
+            backward: selectionIsBackward(selection)
+        };
     }
 
-    function positionAction(range) {
+    function positionAction(range, backward) {
         const visibleRects = Array.from(range.getClientRects()).filter((candidate) =>
             candidate.bottom >= 0
             && candidate.top <= window.innerHeight
             && candidate.right >= 0
             && candidate.left <= window.innerWidth
         );
-        const rect = visibleRects[visibleRects.length - 1];
+        const rect = visibleRects[backward ? 0 : visibleRects.length - 1];
         if (!rect || (!rect.width && !rect.height)) {
             hideAction();
             return;
@@ -219,7 +236,8 @@ function setupSelectionTool() {
         action.style.top = Math.round(top) + 'px';
     }
 
-    function updateAction() {
+    function updateAction(event) {
+        if (event && action.contains(event.target)) return;
         window.clearTimeout(updateTimer);
         updateTimer = window.setTimeout(() => {
             const candidate = selectionInsideSource(window.getSelection());
@@ -228,13 +246,13 @@ function setupSelectionTool() {
                 return;
             }
             active = candidate;
-            positionAction(candidate.range);
+            positionAction(candidate.range, candidate.backward);
         }, 30);
     }
 
-    source.addEventListener('mouseup', updateAction);
     source.addEventListener('keyup', updateAction);
-    source.addEventListener('touchend', updateAction);
+    document.addEventListener('mouseup', updateAction);
+    document.addEventListener('touchend', updateAction);
     action.addEventListener('mousedown', (event) => event.preventDefault());
 
     action.addEventListener('click', async () => {


### PR DESCRIPTION
## Why

This release combines the completed homepage editorial refresh with a follow-up fix for reverse-direction reader highlighting.

Readers selecting text from the end toward the beginning could release the pointer just outside the article content column. The original selection listener was attached only to the content element, so that mouseup event was missed and the “加入公共精选” action stayed hidden. The action was also always positioned from the document-order end of the range instead of the reader's release end.

The homepage also had completed copy and Today’s Issue presentation changes that had not yet been published.

## What changed

- Listen for selection completion at the document level, including touch completion
- Detect backward selections and place the action beside the reader's focus/release end
- Refresh homepage positioning copy and the Editor’s Note, with a link to the reader highlights stream
- Replace the Today’s Issue secondary grid with a compact horizontal carousel and accessible previous/next controls
- Remove the duplicate navigation CTA and simplify the navigation grid
- Add the correct Reddit category label and back-link on Reddit article pages

## Validation

- `node --check js/highlights.js`
- `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 bundle _2.4.22_ exec jekyll build`
- Playwright verified the new homepage copy and seven-card Today’s Issue carousel
- Playwright verified carousel scrolling and previous/next disabled states
- Playwright reproduced reverse selection with mouseup outside the article column and confirmed the action is visible at the release end
- Forward selection regression remained successful
